### PR TITLE
Update uvh5.py, pyuvdata throws error when converting to MS in prev. version

### DIFF
--- a/src/blri/fileformats/uvh5.py
+++ b/src/blri/fileformats/uvh5.py
@@ -133,7 +133,8 @@ def uvh5_initialise(
     uvh5g_header.create_dataset("Nants_telescope", data=len(antennas))
 
     antenna_names = [ant.name for ant in antennas]
-    uvh5g_header.create_dataset("antenna_names", data=numpy.array(antenna_names, dtype=f"S{max(map(len, antenna_names))}"), dtype=h5py.special_dtype(vlen=str))
+    uvh5g_header.create_dataset("antenna_names", data=numpy.array(antenna_names).astype('S4'))
+  #    uvh5g_header.create_dataset("antenna_names", data=numpy.array(antenna_names, dtype=f"S{max(map(len, antenna_names))}"), dtype=h5py.special_dtype(vlen=str))
     uvh5g_header.create_dataset("antenna_numbers", data=numpy.array([ant.number for ant in antennas]), dtype='i')
     uvh5g_header.create_dataset("antenna_diameters", data=numpy.array([ant.diameter for ant in antennas]), dtype='d')
     uvh5g_header.create_dataset("antenna_positions", data=numpy.array([ant.position for ant in antennas]), dtype='d')


### PR DESCRIPTION
Error from pyuvdata is:  

File "/mnt/buf0/jbright/BLRI_STAMP/uvh52ms.py", line 8, in <module>
    uv.read(inp)
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/pyuvdata/uvdata/uvdata.py", line 11139, in read
    self.read_uvh5(
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/pyuvdata/uvdata/uvdata.py", line 9883, in read_uvh5
    uvh5_obj.read_uvh5(filename, **kwargs)
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/pyuvdata/uvdata/uvh5.py", line 1051, in read_uvh5
    self._read_header(
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/pyuvdata/uvdata/uvh5.py", line 680, in _read_header
    self._read_header_with_fast_meta(filename, **kwargs)
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/pyuvdata/uvdata/uvh5.py", line 502, in _read_header_with_fast_meta
    self.telescope = Telescope.from_hdf5(
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/pyuvdata/telescopes.py", line 863, in from_hdf5
    setattr(tel_obj, tel_attr, getattr(meta, attr))
  File "/usr/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/pyuvdata/utils/io/hdf5.py", line 677, in antenna_names
    return np.char.decode(self.header["antenna_names"][:], encoding="utf8")
  File "/mnt/buf0/jbright/BLRI_STAMP/BLRI_STAMP/lib/python3.10/site-packages/numpy/_core/strings.py", line 530, in decode
    _vec_string(a, np.object_, 'decode', _clean_args(encoding, errors)),
TypeError: string operation on non-string array